### PR TITLE
Optimize: Replace TreeSet and TreeMap with SkipLists, also 

### DIFF
--- a/src/main/java/org/owasp/benchmark/score/TestSuiteResults.java
+++ b/src/main/java/org/owasp/benchmark/score/TestSuiteResults.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.TimeUnit;
 
 /*
@@ -54,7 +54,7 @@ public class TestSuiteResults {
     public final boolean isCommercial;
     public final ToolType toolType;
     private Map<Integer, List<TestCaseResult>> testCaseResults =
-            new TreeMap<Integer, List<TestCaseResult>>();
+            new ConcurrentSkipListMap<Integer, List<TestCaseResult>>();
 
     // Used to track if this tool has been anonymized
     private boolean anonymous = false;
@@ -111,6 +111,15 @@ public class TestSuiteResults {
      */
     public Set<Integer> keySet() {
         return testCaseResults.keySet();
+    }
+
+    /**
+     * Get the entryset of all the TestCaseResults for this TestSuite.
+     *
+     * @return The EntrySet of results.
+     */
+    public Set<Map.Entry<Integer, List<TestCaseResult>>> entrySet() {
+        return testCaseResults.entrySet();
     }
 
     /**

--- a/src/main/java/org/owasp/benchmark/score/ToolResults.java
+++ b/src/main/java/org/owasp/benchmark/score/ToolResults.java
@@ -19,7 +19,7 @@ package org.owasp.benchmark.score;
 
 import java.util.Collection;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 /*
  * This class holds all the test results for a single tool's scan of a test suite. It contains CategoryResults for
@@ -30,7 +30,7 @@ public class ToolResults {
 
     // A map of the category name to the results for each category for a specific tool.
     private Map<String, CategoryResults> categoryResultsMap =
-            new TreeMap<String, CategoryResults>();
+            new ConcurrentSkipListMap<String, CategoryResults>();
     private double score =
             0; // The overall score for this tool. Autocalculated when TPR or FPR changed.
     private int total =

--- a/src/main/java/org/owasp/benchmark/score/parsers/AppScanSourceReader.java
+++ b/src/main/java/org/owasp/benchmark/score/parsers/AppScanSourceReader.java
@@ -23,7 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import org.owasp.benchmark.score.BenchmarkScore;
@@ -181,7 +181,7 @@ public class AppScanSourceReader extends Reader {
      * @return
      */
     private Map<Integer, Set<Integer>> parseAssessments(Node root) {
-        Map<Integer, Set<Integer>> map = new TreeMap<Integer, Set<Integer>>();
+        Map<Integer, Set<Integer>> map = new ConcurrentSkipListMap<Integer, Set<Integer>>();
         Node assess1 = getNamedNode("Assessment", root.getChildNodes());
         Node assess2 = getNamedNode("Assessment", assess1.getChildNodes());
         NodeList afiles = assess2.getChildNodes();
@@ -208,7 +208,7 @@ public class AppScanSourceReader extends Reader {
 
     private Map<Integer, String> parsePool(
             Node root, String poolname, String keyname, String valuename, String prefix) {
-        Map<Integer, String> map = new TreeMap<Integer, String>();
+        Map<Integer, String> map = new ConcurrentSkipListMap<Integer, String>();
         Node parent = getNamedNode(poolname, root.getChildNodes());
         NodeList pool = parent.getChildNodes();
         for (int i = 0; i < pool.getLength(); i++) {

--- a/src/main/java/org/owasp/benchmark/tools/NoisyCricket.java
+++ b/src/main/java/org/owasp/benchmark/tools/NoisyCricket.java
@@ -31,7 +31,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.TreeSet;
+import java.util.concurrent.ConcurrentSkipListSet;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.OutputKeys;
@@ -103,7 +103,7 @@ public class NoisyCricket {
     public static void analyze(Path p) throws IOException {
         Element vuln = report.createElement("vulnerability");
         List<String> lines = Files.readAllLines(p, Charset.defaultCharset());
-        Set<Integer> cwelist = new TreeSet<Integer>();
+        Set<Integer> cwelist = new ConcurrentSkipListSet<Integer>();
 
         for (String line : lines) {
             if (checkSQL(line)) {


### PR DESCRIPTION
also replace StringBuffer with StringBuilder

This is a series of performance boosts by replacing the TreeSet and TreeMap classes with the ConcurrentSkipList replacements introduced in Java 1.6 which generally perform better.
https://www.javacodegeeks.com/2017/04/simple-map-iterator-performance-test.html

I also replaced the StringBuffer objects with StringBuilder objects.
StringBuffer objects are slower since they synchronize on every operation, whereas StringBuilder does not synchronize.
In all of the instances I am committing, the StringBuffer objects were local to the method and did not require synchronization.
I ran all of the unit tests and they all ran to completion without any test failures.

This is my first pull request to BenchmarkJava, please excuse any expected actions I did not perform prior to sending this pull request, I will gladly make any changes to fulfill the process to commit code.

Thank you very much,
Larry Diamond