### PR TITLE
Proxy Settings added to OWASP Benchmark Crawler to enable different hosts

### DIFF
--- a/runCrawler.bat
+++ b/runCrawler.bat
@@ -1,3 +1,17 @@
-# source "scripts/verifyBenchmarkPluginAvailable.sh" - Don't have .bat version of this (yet)
-CALL mvn org.owasp:benchmarkutils-maven-plugin:run-crawler -DcrawlerFile=data/benchmark-crawler-http.xml
-
+@echo off
+REM source "scripts/verifyBenchmarkPluginAvailable.sh" - Don't have .bat version of this (yet)
+set /A args_count=0    
+for %%A in (%*) do set /A args_count+=1
+if %args_count% NEQ 0 (
+    if %args_count% EQU 2 (
+        CALL mvn org.owasp:benchmarkutils-maven-plugin:run-crawler -DcrawlerFile=data/benchmark-crawler-http.xml -DproxyHost="%1" -DproxyPort="%2"
+    ) else (
+        echo Error!!
+        echo -------
+        echo To run the Crawler for localhost, execute runCrawler.bat with no arguments.
+        echo To run the Crawler for remote host, execute runCrawler.bat with only 2 arguments, proxy-host and proxy-port.
+        echo Example: runCrawler.bat 192.168.0.1 53452
+    )
+) else (
+    CALL mvn org.owasp:benchmarkutils-maven-plugin:run-crawler -DcrawlerFile=data/benchmark-crawler-http.xml
+)

--- a/runCrawler.sh
+++ b/runCrawler.sh
@@ -1,3 +1,13 @@
+#!/bin/sh
 source "scripts/verifyBenchmarkPluginAvailable.sh"
-mvn org.owasp:benchmarkutils-maven-plugin:run-crawler -DcrawlerFile=data/benchmark-crawler-http.xml
-
+if [ $# -eq 2 ]; then
+    mvn org.owasp:benchmarkutils-maven-plugin:run-crawler -DcrawlerFile=data/benchmark-crawler-http.xml -DproxyHost="$1" -DproxyPort="$2"
+elif [ $# -eq 0 ]; then
+    mvn org.owasp:benchmarkutils-maven-plugin:run-crawler -DcrawlerFile=data/benchmark-crawler-http.xml
+else
+    echo "Error!!"
+    echo "-------"
+    echo "To run the Crawler for localhost, execute runCrawler.sh with no arguments."
+    echo "To run the Crawler for remote host, execute runCrawler.sh with only 2 arguments, proxy-host and proxy-port."
+    echo "Example: ./runCrawler.sh 192.168.0.1 53452"
+fi


### PR DESCRIPTION
This addition would help enable the different hosts to get the OWASP Benchmark Crawler data. Tested it in HCL AppScan as shown below:
![image](https://user-images.githubusercontent.com/36296285/135057293-cdfe7e23-6330-4811-948a-065f2c7323e8.png)

This pull request is dependent on https://github.com/OWASP-Benchmark/BenchmarkUtils/pull/12