### PR TITLE
Update GH actions to their latest versions & include SARIF output

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,14 +25,14 @@ jobs:
         
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       # Get full history for spotless ratchetFrom
       with:
         fetch-depth: 0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
@@ -44,4 +44,12 @@ jobs:
       run: mvn -DskipTests=true install
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
+      with:
+        output: codeql-sarif-${{ matrix.language }}.sarif
+
+    - name: Upload SARIF file
+      uses: actions/upload-artifact@v2
+      with:
+        name: codeql-sarif-${{ matrix.language }}
+        path: codeql-sarif-${{ matrix.language }}.sarif

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -8,13 +8,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: 'zulu'
+        java-version: '8.0.362+9'
     - name: Run spotless check
       run: mvn spotless:check
     - name: Run unit tests


### PR DESCRIPTION
So that CodeQL output can be analysed.
This also updates a bunch of GH actions and removes warnings in the `Actions` tab.