### PR TITLE
Update codeql-analysis.yml to be current

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,13 +1,15 @@
 name: "CodeQL"
 
+env: 
+  CODEQL_EXTRACTOR_JAVA_RUN_ANNOTATION_PROCESSORS: true
+
 on:
   push:
     branches: [ master ]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
-  schedule:
-    - cron: '32 14 * * 0'
+  workflow_dispatch:
 
 jobs:
   analyze:
@@ -17,7 +19,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-
+    
     strategy:
       fail-fast: false
       matrix:
@@ -25,23 +27,27 @@ jobs:
         
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       # Get full history for spotless ratchetFrom
       with:
         fetch-depth: 0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-    #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v1
+        queries: security-extended, security-experimental, security-and-quality
       
     - name: Build with Maven
       run: mvn -DskipTests=true install
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
+      
+    - name: Upload Output
+      uses: actions/upload-artifact@v3
+      with:
+        name: ${{ matrix.language }} SARIF
+        path: ${{ runner.workspace }}/results/*.sarif
+        


### PR DESCRIPTION
* Update codeql-analysis.yml

This changeset alters the CodeQL analysis Action to run an expanded ruleset, leverages the "free for OSS" nature to produce an uploaded resultfile that can be included with the BenchmarkJava suite, removes the scheduled runs and allows manual triggers instead, and updates all actions to their latest versions.