### PR TITLE
Update HCL IAST Log Path

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -584,7 +584,7 @@
                                     <cargo.jvmargs>
                                         -Xmx8G
                                         -javaagent:${basedir}/tools/HCL/secagent.jar=agent_path=${basedir}/tools/HCL/secagent.jar
-                                        -Dsecagent.log=${basedir}/tools/HCL/HCL-IAST.hcl
+                                        -Dsecagent.log=${basedir}/results/HCL-IAST.hcl
                                     </cargo.jvmargs>
                                     <cargo.servlet.port>8443</cargo.servlet.port>
                                     <cargo.protocol>https</cargo.protocol>

--- a/tools/HCL/runBenchmark_wHCL.bat
+++ b/tools/HCL/runBenchmark_wHCL.bat
@@ -1,8 +1,8 @@
 @ECHO OFF
 IF EXIST .\secagent.jar (
-  IF EXIST .\HCL-IAST.hcl (
+  IF EXIST ..\..\results\HCL-IAST.hcl (
 
-        DEL .\HCL-IAST.hcl
+        DEL ..\..\results\HCL-IAST.hcl
 
         ECHO.
         ECHO Previous results have been removed
@@ -11,17 +11,17 @@ IF EXIST .\secagent.jar (
 
     CD ..\..
 
-    ECHO After Crawl is Complete, hit Ctrl-C to stop Benchmark Tomcat instance.
-    ECHO When it asks "Terminate batch job (Y/N)?" Enter N, so script will complete and copy results to /results directory.
-    ECHO.
+    @REM ECHO After Crawl is Complete, hit Ctrl-C to stop Benchmark Tomcat instance.
+    @REM ECHO When it asks "Terminate batch job (Y/N)?" Enter N, so script will complete and copy results to /results directory.
+    @REM ECHO.
 
     CALL mvn clean package cargo:run -Pdeploywhcl -Drunenv=remote
 
-    ECHO Copying HCL reports to results directory
+    @REM ECHO Copying HCL reports to results directory
 
-    COPY tools\HCL\HCL-IAST.hcl results\Benchmark_HCL-IAST.hcl
+    @REM COPY tools\HCL\HCL-IAST.hcl results\Benchmark_HCL-IAST.hcl
 
-    CD tools\HCL
+    @REM CD tools\HCL
 
 ) ELSE (
     ECHO HCL is a commercial product, so you need a licensed version of HCL in order to run it on the Benchmark. If you have access to HCL, download the HCL Agent for Java ^(secagent.jar^), put it into the /tools/HCL folder, and then rerun this script. Please contact HCL at https://www.hcl.com/.

--- a/tools/HCL/runBenchmark_wHCL.bat
+++ b/tools/HCL/runBenchmark_wHCL.bat
@@ -11,17 +11,7 @@ IF EXIST .\secagent.jar (
 
     CD ..\..
 
-    @REM ECHO After Crawl is Complete, hit Ctrl-C to stop Benchmark Tomcat instance.
-    @REM ECHO When it asks "Terminate batch job (Y/N)?" Enter N, so script will complete and copy results to /results directory.
-    @REM ECHO.
-
     CALL mvn clean package cargo:run -Pdeploywhcl -Drunenv=remote
-
-    @REM ECHO Copying HCL reports to results directory
-
-    @REM COPY tools\HCL\HCL-IAST.hcl results\Benchmark_HCL-IAST.hcl
-
-    @REM CD tools\HCL
 
 ) ELSE (
     ECHO HCL is a commercial product, so you need a licensed version of HCL in order to run it on the Benchmark. If you have access to HCL, download the HCL Agent for Java ^(secagent.jar^), put it into the /tools/HCL folder, and then rerun this script. Please contact HCL at https://www.hcl.com/.

--- a/tools/HCL/runBenchmark_wHCL.sh
+++ b/tools/HCL/runBenchmark_wHCL.sh
@@ -2,9 +2,9 @@
 
 if [ -f ./secagent.jar ]; then
 
-  if [ -d ./HCL-IAST.hcl ]; then
+  if [ -d ../../results/HCL-IAST.hcl ]; then
 
-    rm ./HCL-IAST.hcl
+    rm ../../results/HCL-IAST.hcl
     echo ""
     echo "Previous results have been removed"
     echo ""
@@ -13,12 +13,6 @@ if [ -f ./secagent.jar ]; then
 
   cd ../..
   mvn clean package cargo:run -Pdeploywhcl -Drunenv=remote
-
-  echo "Copying report to results directory"
-  benchmark_version=$(scripts/getBenchmarkVersion.sh)
-  result_file="results/Benchmark_$benchmark_version-HCL-IAST.hcl"
-  cp tools/HCL/HCL-IAST.hcl "$result_file"
-  cd tools/HCL
 
 else 
 


### PR DESCRIPTION
Targeting the results file directly to results directory instead of copying it after the crawler is done and the server stopped