### PR TITLE
fix(dockerfile): deprecated Dockerfile instructions

### DIFF
--- a/VMs/Dockerfile
+++ b/VMs/Dockerfile
@@ -1,6 +1,6 @@
 # This dockerfile builds a container that pulls down and runs the latest version of BenchmarkJava
 FROM ubuntu:latest
-MAINTAINER "Dave Wichers dave.wichers@owasp.org"
+LABEL org.opencontainers.image.authors="Dave Wichers dave.wichers@owasp.org"
 
 RUN apt-get update
 RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata

--- a/VMs/Dockerfile
+++ b/VMs/Dockerfile
@@ -35,7 +35,7 @@ RUN useradd -d /home/bench -m -s /bin/bash bench
 RUN echo bench:bench | chpasswd
 
 RUN chown -R bench /owasp/
-ENV PATH /owasp/BenchmarkJava:$PATH
+ENV PATH=/owasp/BenchmarkJava:$PATH
 
 # start up Benchmark once, for 60 seconds, then kill it, so the additional dependencies required to run it are downloaded/cached in the image as well.
 # exit 0 is required to return a 'success' code, otherwise the timeout returns a failure code, causing the Docker build to fail.


### PR DESCRIPTION
This PR addresses the two warnings in the image below while building the Docker image
![image](https://github.com/OWASP-Benchmark/BenchmarkJava/assets/2962581/e1809519-0d12-46d5-96ea-ada3529ba523)
