### PR TITLE
Update Dockerfile to use java 17

### DIFF
--- a/VMs/Dockerfile
+++ b/VMs/Dockerfile
@@ -5,8 +5,8 @@ MAINTAINER "Dave Wichers dave.wichers@owasp.org"
 RUN apt-get update
 RUN DEBIAN_FRONTEND="noninteractive" apt-get -y install tzdata
 RUN apt-get install -q -y \
-     openjdk-11-jre-headless \
-     openjdk-11-jdk \
+     openjdk-17-jre-headless \
+     openjdk-17-jdk \
      git \
      maven \
      wget \


### PR DESCRIPTION
This PR updates the Java installed in the Docker container from version 11 to 17.
This is necessary as the upgrade of spotless dependency required Java 17 for maven build. (see 2cf91fa)
Otherwise, building the Docker image fails.