### PR TITLE
Add fetchZAPResults.sh script to download ZAP reports from a URL

### DIFF
--- a/scripts/fetchZAPResults.sh
+++ b/scripts/fetchZAPResults.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Downloads a ZAP XML report from a URL and saves it to the results/ directory.
+# After downloading, run createScorecards.sh to generate the scorecard.
+#
+# Usage: scripts/fetchZAPResults.sh <ZAP_REPORT_URL> [OUTPUT_FILENAME]
+#
+# Examples:
+#   scripts/fetchZAPResults.sh http://172.17.0.3:8090/OTHER/core/other/xmlreport/
+#   scripts/fetchZAPResults.sh "http://zap:8090/OTHER/core/other/xmlreport/?apikey=abc123"
+#   scripts/fetchZAPResults.sh http://zap:8090/OTHER/core/other/xmlreport/ my-zap-results.xml
+
+source scripts/requireCommand.sh
+
+requireCommand curl
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <ZAP_REPORT_URL> [OUTPUT_FILENAME]"
+    echo ""
+    echo "Downloads a ZAP XML report from the given URL and saves it to results/."
+    echo "After downloading, run createScorecards.sh to generate the scorecard."
+    echo ""
+    echo "Examples:"
+    echo "  $0 http://172.17.0.3:8090/OTHER/core/other/xmlreport/"
+    echo "  $0 \"http://zap:8090/OTHER/core/other/xmlreport/?apikey=abc123\""
+    echo "  $0 http://zap:8090/OTHER/core/other/xmlreport/ my-zap-results.xml"
+    exit 1
+fi
+
+zap_url="$1"
+
+if [ $# -ge 2 ]; then
+    filename="$2"
+else
+    benchmark_version=$(scripts/getBenchmarkVersion.sh)
+    date_stamp=$(date +%Y%m%d)
+    filename="Benchmark_${benchmark_version}-ZAP-${date_stamp}.xml"
+fi
+
+output="results/${filename}"
+
+echo "Downloading ZAP report from: ${zap_url}"
+http_code=$(curl -sS -o "${output}" -w '%{http_code}' --connect-timeout 10 --max-time 120 "${zap_url}")
+
+if [ "${http_code}" -ne 200 ]; then
+    echo "ERROR: Download failed with HTTP status ${http_code}"
+    rm -f "${output}"
+    exit 1
+fi
+
+if ! head -2 "${output}" | grep -q "OWASPZAPReport"; then
+    echo "ERROR: Downloaded file does not appear to be a ZAP XML report."
+    echo "First 3 lines of downloaded content:"
+    head -3 "${output}"
+    rm -f "${output}"
+    exit 1
+fi
+
+echo "ZAP report saved to: ${output}"
+echo "To generate the scorecard, run: ./createScorecards.sh"

--- a/scripts/fetchZAPResults.sh
+++ b/scripts/fetchZAPResults.sh
@@ -3,55 +3,72 @@
 # Downloads a ZAP XML report from a URL and saves it to the results/ directory.
 # After downloading, run createScorecards.sh to generate the scorecard.
 #
-# Usage: scripts/fetchZAPResults.sh <ZAP_REPORT_URL> [OUTPUT_FILENAME]
+# Usage: scripts/fetchZAPResults.sh <ZAP_REPORT_URL> [OUTPUT_FILENAME] [API_KEY]
 #
 # Examples:
 #   scripts/fetchZAPResults.sh http://172.17.0.3:8090/OTHER/core/other/xmlreport/
-#   scripts/fetchZAPResults.sh "http://zap:8090/OTHER/core/other/xmlreport/?apikey=abc123"
 #   scripts/fetchZAPResults.sh http://zap:8090/OTHER/core/other/xmlreport/ my-zap-results.xml
+#   scripts/fetchZAPResults.sh http://zap:8090/OTHER/core/other/xmlreport/ "" my-secret-api-key
 
 source scripts/requireCommand.sh
 
 requireCommand curl
 
 if [ $# -eq 0 ]; then
-    echo "Usage: $0 <ZAP_REPORT_URL> [OUTPUT_FILENAME]"
-    echo ""
-    echo "Downloads a ZAP XML report from the given URL and saves it to results/."
-    echo "After downloading, run createScorecards.sh to generate the scorecard."
-    echo ""
-    echo "Examples:"
-    echo "  $0 http://172.17.0.3:8090/OTHER/core/other/xmlreport/"
-    echo "  $0 \"http://zap:8090/OTHER/core/other/xmlreport/?apikey=abc123\""
-    echo "  $0 http://zap:8090/OTHER/core/other/xmlreport/ my-zap-results.xml"
+    echo "Usage: $0 <ZAP_REPORT_URL> [OUTPUT_FILENAME] [API_KEY]" >&2
+    echo "" >&2
+    echo "Downloads a ZAP XML report from the given URL and saves it to results/." >&2
+    echo "After downloading, run createScorecards.sh to generate the scorecard." >&2
+    echo "" >&2
+    echo "Arguments:" >&2
+    echo "  ZAP_REPORT_URL   URL to the ZAP XML report endpoint" >&2
+    echo "  OUTPUT_FILENAME   Optional custom filename (saved under results/)" >&2
+    echo "  API_KEY           Optional ZAP API key (passed via header, not in URL)" >&2
+    echo "" >&2
+    echo "Examples:" >&2
+    echo "  $0 http://172.17.0.3:8090/OTHER/core/other/xmlreport/" >&2
+    echo "  $0 http://zap:8090/OTHER/core/other/xmlreport/ my-zap-results.xml" >&2
+    echo "  $0 http://zap:8090/OTHER/core/other/xmlreport/ \"\" my-secret-api-key" >&2
     exit 1
 fi
 
 zap_url="$1"
 
-if [ $# -ge 2 ]; then
+if [ -n "${2:-}" ]; then
     filename="$2"
 else
     benchmark_version=$(scripts/getBenchmarkVersion.sh)
+    if [ -z "${benchmark_version}" ]; then
+        echo "ERROR: Could not determine Benchmark version from pom.xml." >&2
+        exit 1
+    fi
     date_stamp=$(date +%Y%m%d)
     filename="Benchmark_${benchmark_version}-ZAP-${date_stamp}.xml"
 fi
 
+api_key="${3:-}"
+
+mkdir -p results/
 output="results/${filename}"
 
+curl_args=(-sS -o "${output}" -w '%{http_code}' --connect-timeout 10 --max-time 120)
+if [ -n "${api_key}" ]; then
+    curl_args+=(-H "X-ZAP-API-Key: ${api_key}")
+fi
+
 echo "Downloading ZAP report from: ${zap_url}"
-http_code=$(curl -sS -o "${output}" -w '%{http_code}' --connect-timeout 10 --max-time 120 "${zap_url}")
+http_code=$(curl "${curl_args[@]}" "${zap_url}")
 
 if [ "${http_code}" -ne 200 ]; then
-    echo "ERROR: Download failed with HTTP status ${http_code}"
+    echo "ERROR: Download failed with HTTP status ${http_code}" >&2
     rm -f "${output}"
     exit 1
 fi
 
 if ! head -2 "${output}" | grep -q "OWASPZAPReport"; then
-    echo "ERROR: Downloaded file does not appear to be a ZAP XML report."
-    echo "First 3 lines of downloaded content:"
-    head -3 "${output}"
+    echo "ERROR: Downloaded file does not appear to be a ZAP XML report." >&2
+    echo "First 3 lines of downloaded content:" >&2
+    head -3 "${output}" >&2
     rm -f "${output}"
     exit 1
 fi


### PR DESCRIPTION
## Summary
Closes #21

Adds a shell script (`scripts/fetchZAPResults.sh`) that downloads a ZAP XML report from a remote ZAP instance via its REST API and saves it to the `results/` directory. This enables scorecard generation when ZAP and Benchmark run in separate Docker containers without a shared filesystem.

## Motivation

As described in #21, when ZAP runs in one Docker container and the Benchmark app runs in another, there is no shared filesystem to place a ZAP XML report into the `results/` directory. This script bridges that gap by fetching the report over HTTP from ZAP's REST API.

## Usage

```bash
# Download ZAP XML report from a running ZAP instance
scripts/fetchZAPResults.sh http://172.17.0.3:8090/OTHER/core/other/xmlreport/

# With ZAP API key
scripts/fetchZAPResults.sh "http://zap:8090/OTHER/core/other/xmlreport/?apikey=abc123"

# With custom output filename
scripts/fetchZAPResults.sh http://zap:8090/OTHER/core/other/xmlreport/ my-zap-results.xml

# Then generate the scorecard as usual
./createScorecards.sh
```

The script auto-generates the output filename using the Benchmark version from `pom.xml` and the current date (e.g., `Benchmark_1.2-ZAP-20260413.xml`), matching the existing naming convention in `results/`.

## What it does

1. Validates that `curl` is available (via existing `requireCommand.sh`)
2. Downloads the ZAP XML report from the provided URL
3. Validates the response is actually a ZAP report (checks for `<OWASPZAPReport` marker)
4. Saves to `results/` with a properly formatted filename
5. Cleans up on failure (HTTP errors or invalid content) so `results/` stays clean

## Design decisions

- **Follows existing patterns**: Uses `curl` (like `runSonarQube.sh`), `requireCommand.sh` (like `runBearer.sh`, `runSemgrep.sh`), and `getBenchmarkVersion.sh` (like `runBearer.sh`, `runSemgrep.sh`, `runCodeQL.sh`)
- **Separation of concerns**: Downloads results only; scorecard generation remains a separate step via `createScorecards.sh`, matching how every other tool in the project works
- **Content validation**: Verifies the download is a ZAP XML report before saving, preventing 404 pages or HTML errors from landing in `results/` and confusing the scorecard generator

## What is NOT changed

- No existing files modified
- No `pom.xml` / dependency changes
- No changes to `src/main/java/org/owasp/benchmark/testcode/`
- No BenchmarkUtils changes needed (existing `ZapReader` already handles the downloaded XML)

## Test plan

- [ ] Run `scripts/fetchZAPResults.sh` with no arguments -- should print usage and exit 1
- [ ] Run against a ZAP instance URL -- should download the XML and save to `results/`
- [ ] Run against a bad URL -- should report HTTP error and clean up
- [ ] Run `./createScorecards.sh` after downloading -- scorecard should include the new ZAP results
